### PR TITLE
Add DNS zone for kitzysound.com

### DIFF
--- a/dns_zones/kitzysound.com.yml
+++ b/dns_zones/kitzysound.com.yml
@@ -1,0 +1,60 @@
+zone_name: "kitzysound.com"
+records:
+  - name: "kitzysound.com"
+    type: "A"
+    ttl: 300
+    values:
+      - "198.185.159.144"
+      - "198.185.159.145"
+      - "198.49.23.144"
+      - "198.49.23.145"
+  - name: "www"
+    type: "CNAME"
+    ttl: 300
+    values:
+      - "ext-cust.squarespace.com"
+  - name: "47t3gdz7nppxyrwxz5sp"
+    type: "CNAME"
+    ttl: 900
+    values:
+      - "verify.squarespace.com"
+  - name: "kitzysound.com"
+    type: "MX"
+    ttl: 900
+    values:
+      - "1 aspmx.l.google.com"
+      - "10 alt3.aspmx.l.google.com"
+      - "10 alt4.aspmx.l.google.com"
+      - "5 alt1.aspmx.l.google.com"
+      - "5 alt2.aspmx.l.google.com"
+  - name: "kitzysound.com"
+    type: "TXT"
+    ttl: 900
+    values:
+      - "google-site-verification=vSXT3TxITKwK3Re5A3bdo-lTDU1ITQEjnLOo64fvJu0"
+      - "google-site-verification=9W_ciHGBbufALyTyzxlbxmQn8S9MHHrhF2Mt0l2v5uE"
+      - "v=spf1 include:_spf.google.com include:mailgun.org ~all"
+  - name: "google._domainkey"
+    type: "TXT"
+    ttl: 300
+    values:
+      - "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCd+WJKhzXXmargV+GZ8ZzC1poQ+AwWAV2JzkrmpdEpsFiYE3W+AkhcW/WewwlcBJDL08N/UizVldRhAJHM/9iFcj8ZcRqjAoRhIDnpqMyT63qTOM03mO5Yhdu1OJbdoSYFgvgLgA3ertpgC/7WE/8lbDRypsQkK5MoW3mInTch7QIDAQAB"
+  - name: "_dmarc"
+    type: "TXT"
+    ttl: 300
+    values:
+      - "v=DMARC1; p=quarantine; pct=5; rua=mailto:postmaster@kitzysound.com"
+  - name: "_domainkey"
+    type: "TXT"
+    ttl: 0
+    values: []
+  - name: "kdu4b3bf2yvj"
+    type: "CNAME"
+    ttl: 900
+    values:
+      - "gv-7l3jfpbxnyec54.dv.googlehosted.com"
+  - name: "smtp._domainkey"
+    type: "TXT"
+    ttl: 900
+    values:
+      - "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDotX3ARWVrMjEl3ww6CfC8vOdmPDL3DbaOywLSNiyMAeFtwvUqmV0YZ/9fCgJodtrNNoFKOKK7s6uQm37Qh43X1pSBg5LPVdITPhUqa/fIKGMlnpCfVFdnUlwe24F/O/Y+xATx7CzxUPgKpWU2TddsEESLm2anH6isZ0M0XRtJ8wIDAQAB"


### PR DESCRIPTION
## Summary
- add YAML definition for kitzysound.com DNS zone

## Testing
- `python - <<'PY'
import yaml,sys
with open('dns_zones/kitzysound.com.yml') as f:
    data=yaml.safe_load(f)
print('zone:', data['zone_name'], 'records:', len(data['records']))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb8291c588321bc55efa722d82616