### PR TITLE
Handle wildcard names in Route53 cleanup

### DIFF
--- a/scripts/cleanup_route53.py
+++ b/scripts/cleanup_route53.py
@@ -41,7 +41,7 @@ for filename in os.listdir(DNS_ZONES_DIR):
             rtype = record["Type"]
             if rtype in ("NS", "SOA"):
                 continue
-            name = record["Name"].rstrip(".")
+            name = record["Name"].rstrip(".").replace("\\052", "*")
             set_id = record.get("SetIdentifier")
             key = (name, rtype, set_id)
             if key not in defined:


### PR DESCRIPTION
## Summary
- Convert AWS-escaped wildcard markers (\052) back to '*' when iterating Route53 records

## Testing
- `python scripts/cleanup_route53.py` *(fails: botocore.exceptions.NoCredentialsError: Unable to locate credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68bee453f4808321bc7be57f2b04bda4