### PR TITLE
Add _atproto TXT record to kitzy.com DNS zone

### DIFF
--- a/dns_zones/kitzy.com.yml
+++ b/dns_zones/kitzy.com.yml
@@ -37,3 +37,8 @@ records:
     ttl: 300
     values:
       - "v=DMARC1; p=quarantine; pct=5; rua=mailto:postmaster@kitzy.com"
+  - name: "_atproto"
+    type: "TXT"
+    ttl: 300
+    values:
+      - "did=did:plc:fvl42rg3p6oqkpwjhdn7mljm"


### PR DESCRIPTION
Introduces a new TXT record for _atproto with a DID value to the kitzy.com DNS zone file.