### PR TITLE
Update DNS records for kitzy.com to support GitHub Pages

### DIFF
--- a/dns_zones/kitzy.com.yml
+++ b/dns_zones/kitzy.com.yml
@@ -1,11 +1,27 @@
 zone_name: "kitzy.com"
 records:
-  - name: "*"
+  - name: "kitzy.com"
     ttl: 300
     type: A
     values:
-      - "100.34.107.84"
+      - "185.199.108.153"
+      - "185.199.109.153"
+      - "185.199.110.153"
+      - "185.199.111.153"
   - name: "kitzy.com"
+    type: "AAAA"
+    ttl: 300
+    values:
+      - "2606:50c0:8000::153"
+      - "2606:50c0:8001::153"
+      - "2606:50c0:8002::153"
+      - "2606:50c0:8003::153"
+  - name: "www"
+    ttl: 300
+    type: CNAME
+    values:
+      - "kitzy.github.io"
+  - name: "*"
     ttl: 300
     type: A
     values:


### PR DESCRIPTION
Add A and AAAA records for kitzy.com and configure CNAME for www to point to GitHub Pages.