### PR TITLE
Change wildcard DNS record from A to CNAME for kitzy.com

### DIFF
--- a/dns_zones/kitzy.com.yml
+++ b/dns_zones/kitzy.com.yml
@@ -23,9 +23,9 @@ records:
       - "kitzy.github.io"
   - name: "*"
     ttl: 300
-    type: A
+    type: CNAME
     values:
-      - "100.34.107.84"
+      - "kitzy.github.io"
   - name: "kitzy.com"
     type: "MX"
     ttl: 300


### PR DESCRIPTION
Update the wildcard DNS record for kitzy.com from an A record to a CNAME record pointing to kitzy.github.io.