### PR TITLE
Add CNAME record for status page in DNS configuration

### DIFF
--- a/dns_zones/kitzy.net.yml
+++ b/dns_zones/kitzy.net.yml
@@ -5,6 +5,11 @@ records:
     type: MX
     values:
       - "1 smtp.google.com"
+  - name: "status"
+    ttl: 300
+    type: CNAME
+    values:
+      - "statuspage.betteruptime.com"
   - name: "*"
     ttl: 300
     type: A


### PR DESCRIPTION
Introduce a CNAME record for the status page in the kitzy.net DNS settings to enhance monitoring and uptime visibility.