### PR TITLE
Add support for multiple providers in kitzy.com DNS configuration

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -70,7 +70,7 @@ jobs:
             zones:
               - 'dns_zones/*.yml'
       - name: Setup Terraform
-        if: steps.changes.outputs.terraform == 'true'
+        if: steps.changes.outputs.terraform == 'true' || steps.changes.outputs.zones == 'true'
         uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,23 +67,25 @@ jobs:
           filters: |
             terraform:
               - '**/*.tf'
+            zones:
+              - 'dns_zones/*.yml'
       - name: Setup Terraform
         if: steps.changes.outputs.terraform == 'true'
         uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
       - name: Terraform init
-        if: steps.changes.outputs.terraform == 'true'
+        if: steps.changes.outputs.terraform == 'true' || steps.changes.outputs.zones == 'true'
         working-directory: terraform
         run: terraform init
       - name: Terraform validate
-        if: steps.changes.outputs.terraform == 'true'
+        if: steps.changes.outputs.terraform == 'true' || steps.changes.outputs.zones == 'true'
         working-directory: terraform
         run: terraform validate
       - name: Terraform plan
-        if: steps.changes.outputs.terraform == 'true'
+        if: steps.changes.outputs.terraform == 'true' || steps.changes.outputs.zones == 'true'
         working-directory: terraform
         run: terraform plan -no-color -input=false
       - name: Skip plan
-        if: steps.changes.outputs.terraform != 'true'
+        if: steps.changes.outputs.terraform != 'true' && steps.changes.outputs.zones != 'true'
         run: echo 'No Terraform changes detected; skipping plan.'

--- a/dns_zones/kitzy.com.yml
+++ b/dns_zones/kitzy.com.yml
@@ -1,5 +1,7 @@
 zone_name: "kitzy.com"
-provider: route53
+providers: 
+  - route53
+  - cloudflare
 records:
   - name: "kitzy.com"
     ttl: 300

--- a/dns_zones/kitzy.com.yml
+++ b/dns_zones/kitzy.com.yml
@@ -1,5 +1,5 @@
 zone_name: "kitzy.com"
-providers: 
+providers:
   - route53
   - cloudflare
 records:


### PR DESCRIPTION
Enable configuration for multiple DNS providers, including Route53 and Cloudflare, in the kitzy.com setup.